### PR TITLE
Rename `url` to `source` in PRCA metadata

### DIFF
--- a/scrapers/prca/fetch_prca.py
+++ b/scrapers/prca/fetch_prca.py
@@ -77,15 +77,15 @@ class FetchPRCA():
 
     def fetch_file(self, record):
         # name the file
-        file_type = record["url"][-3:]
+        file_type = record["source"][-3:]
         filename = "%s_%s_%s.%s" % (record["description"], record["date_from"][:7], record["date_to"][:7], file_type)
         full_path = os.path.join(self.current_path, self.STORE_DIR, filename)
         # fetch from URL and save locally
         try:
-            _ = urllib.urlretrieve(record["url"], full_path)
+            _ = urllib.urlretrieve(record["source"], full_path)
             time.sleep(0.5)
         except IOError:
-            self._logger.error("URL not found: %s" % record["url"])
+            self._logger.error("URL not found: %s" % record["source"])
             raise
         # record filename and timestamp in the db
         record["filename"] = filename
@@ -112,7 +112,7 @@ class FetchPRCA():
             else:
                 # store a record in the db, but with fetched=False
                 current["fetched"] = False
-                current["url"] = "%s%s" % (self.BASE_URL, rel_url)
+                current["source"] = "%s%s" % (self.BASE_URL, rel_url)
                 current["linked_from"] = self.index_url
                 self.db.save(self.COLLECTION_NAME, current)
             self.fetch_file(current)

--- a/scrapers/prca/scrape_prca.py
+++ b/scrapers/prca/scrape_prca.py
@@ -11,7 +11,7 @@ class ScrapePRCA():
         self._logger = logging.getLogger('spud')
         self.db = mongo.MongoInterface()
         # prefix for database tables
-        self.prefix = "prca"
+        self.PREFIX = "prca"
         # directory where files are stored
         self.STORE_DIR = "store"
         # the y-position of the top of the footer
@@ -147,7 +147,7 @@ class ScrapePRCA():
                 self._logger.debug("%s:      %s" % (k, v))
             self._logger.debug("---")
 
-            agency_entity = self.db.save("%s_scrape" % self.prefix, agency)
+            agency_entity = self.db.save("%s_scrape" % self.PREFIX, agency)
 
     # # TODO! This is wrong at the moment
     # def parse_contact(self, agency):
@@ -185,7 +185,7 @@ class ScrapePRCA():
         self.save_to_db(sorted_agencies, meta)
 
     def run(self):
-        metas = self.db.fetch_all("%s_fetch" % self.prefix, paged=False)
+        metas = self.db.fetch_all("%s_fetch" % self.PREFIX, paged=False)
 
         for meta in metas:
             if not meta["filename"].endswith(".pdf"):


### PR DESCRIPTION
Very minor fix. I actually wonder if it might be better to make `source` a dictionary that includes the page number (since this is really source information).